### PR TITLE
Change the publication strategy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @bgatellier

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,20 +32,15 @@ on:
           - lockStepVersion
         default: "individualVersion"
         required: true
-  # debug
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      # MODE: ${{ inputs.MODE }}
-      MODE: "publish"
+      MODE: ${{ inputs.MODE }}
       SOURCE_BRANCH: master # Force the master branch to be deployed: avoid the publication of WIP code from other branches
       TARGET_BRANCH: release/${{ github.run_id }}
-      # VERSION_POLICY: ${{ inputs.VERSION_POLICY }}
-      VERSION_POLICY: "individualVersion"
+      VERSION_POLICY: ${{ inputs.VERSION_POLICY }}
     permissions:
       contents: write
       pull-requests: write
@@ -89,9 +84,9 @@ jobs:
         if: ${{ env.MODE == 'publish' }}
         run: node common/scripts/install-run-rush.js version --bump --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
-      # - name: Publish to npmjs.org with the version policy ${{ env.VERSION_POLICY }}
-      #   if: ${{ env.MODE == 'publish' }}
-      #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
+      - name: Publish to npmjs.org with the version policy ${{ env.VERSION_POLICY }}
+        if: ${{ env.MODE == 'publish' }}
+        run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
 
       - name: Create a Pull Request
         if: ${{ env.MODE == 'publish' }}
@@ -101,12 +96,12 @@ jobs:
 
       # We use a PAT (Personal Access Token) to do the following operations on the PR, as $GITHUB_TOKEN cannot review his own PR and cannot enforce repository settings.
       # We use a merge commit to preserve Git tags added by the previous step and move them to the $TARGET_BRANCH.
-      # gh pr merge $TARGET_BRANCH --merge --admin --delete-branch
       # To make the merge commit work (--merge option), the "Allow merge commits" option must be checked in the repository settings.
       # As the "Require linear history" option of the $SOURCE_BRANCH protected branch is on, we enforce this setting with the --admin flag.
       - name: Review and merge the Pull Request, then delete the branch
         if: ${{ env.MODE == 'publish' }}
         run: |
           gh pr review $TARGET_BRANCH --approve
+          gh pr merge $TARGET_BRANCH --merge --admin --delete-branch
         env:
           GH_TOKEN: ${{ secrets.BGATELLIER_PAT }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,8 +99,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Use --merge to keep the Git tags added by the previous step and move them to the $TARGET_BRANCH
-      # gh pr merge $TARGET_BRANCH --merge --auto --delete-branch
+      # We use a PAT (Personal Access Token) to do the following operations on the PR, as $GITHUB_TOKEN cannot review his own PR and cannot enforce repository settings.
+      # We use a merge commit to preserve Git tags added by the previous step and move them to the $TARGET_BRANCH.
+      # gh pr merge $TARGET_BRANCH --merge --admin --delete-branch
+      # To make the merge commit work (--merge option), the "Allow merge commits" option must be checked in the repository settings.
+      # As the "Require linear history" option of the $SOURCE_BRANCH protected branch is on, we enforce this setting with the --admin flag.
       - name: Review and merge the Pull Request, then delete the branch
         if: ${{ env.MODE == 'publish' }}
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # MODE: ${{ inputs.MODE }}
-      MODE: "simulate"
+      MODE: "publish"
       SOURCE_BRANCH: master # Force the master branch to be deployed: avoid the publication of WIP code from other branches
       TARGET_BRANCH: release/${{ github.run_id }}
       # VERSION_POLICY: ${{ inputs.VERSION_POLICY }}
@@ -72,7 +72,7 @@ jobs:
         if: ${{ env.MODE == 'simulate' }}
         run: node common/scripts/install-run-rush.js version --bump --version-policy $VERSION_POLICY
 
-      - name: Simulate a publication to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
+      - name: Simulate a publication to npmjs.org with the version policy ${{ env.VERSION_POLICY }}
         if: ${{ env.MODE == 'simulate' }}
         run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
@@ -89,14 +89,15 @@ jobs:
         if: ${{ env.MODE == 'publish' }}
         run: node common/scripts/install-run-rush.js version --bump --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
-      # - name: Publish to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
+      # - name: Publish to npmjs.org with the version policy ${{ env.VERSION_POLICY }}
       #   if: ${{ env.MODE == 'publish' }}
       #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
 
       - name: Create, approve and merge a Pull Request
         if:
           ${{ env.MODE == 'publish' }}
-          # gh pr merge $TARGET_BRANCH --admin --squash --delete-branch
+          # Use --merge to keep the Git tags added by the previous step and move them to the $TARGET_BRANCH
+          # gh pr merge $TARGET_BRANCH --admin --merge --delete-branch
         run: |
           gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published"
           gh pr review $TARGET_BRANCH --approve

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,14 +95,15 @@ jobs:
 
       - name: Create a Pull Request
         if: ${{ env.MODE == 'publish' }}
-        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published" --no-maintainer-edit
+        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --fill --no-maintainer-edit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Use --merge to keep the Git tags added by the previous step and move them to the $TARGET_BRANCH
+      # gh pr merge $TARGET_BRANCH --merge --auto --delete-branch
       - name: Review and merge the Pull Request, then delete the branch
         if: ${{ env.MODE == 'publish' }}
-        # Use --merge to keep the Git tags added by the previous step and move them to the $TARGET_BRANCH
-        # gh pr merge $TARGET_BRANCH --admin --merge --delete-branch
-        run: gh pr review $TARGET_BRANCH --approve
+        run: |
+          gh pr review $TARGET_BRANCH --approve
         env:
           GH_TOKEN: ${{ secrets.BGATELLIER_PAT }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,22 +23,27 @@ on:
           - lockStepVersion
         default: "individualVersion"
         required: true
+  # debug
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     env:
       MODE: ${{ inputs.MODE }}
-      # Force the master branch to be deployed: avoid the publication of WIP code from other branches
-      TARGET_BRANCH: master
+      SOURCE_BRANCH: master # Force the master branch to be deployed: avoid the publication of WIP code from other branches
+      TARGET_BRANCH: release/${{ github.run_id }}
       VERSION_POLICY: ${{ inputs.VERSION_POLICY }}
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+          ref: ${{ env.SOURCE_BRANCH }}
 
       - uses: actions/setup-node@v3
         with:
@@ -47,23 +52,30 @@ jobs:
       - name: Git config user
         uses: snow-actions/git-config-user@v1.0.0
         with:
-          name: Fabernovel
+          name: Heart
           email: heart@fabernovel.com
 
-      # As we are using the version policies, we need to bump versions first:
+      - name: Debug
+        run: env
+
+      - name: Create origin/${{ env.TARGET_BRANCH }} branch and switch to it
+        run: git checkout -b $TARGET_BRANCH
+
+      # As we are using Rush version policies feature, we need to bump versions first:
       # https://rushjs.io/pages/maintainer/publishing/#publishing-process-when-version-policies-are-used
-      - name: Simulate packages versions numbers bump
-        if: ${{ env.MODE == 'simulate' }}
-        run: node common/scripts/install-run-rush.js version --bump --version-policy $VERSION_POLICY
+      - name: Bump packages versions numbers
+        if: ${{ env.MODE == 'publish' }}
+        run: node common/scripts/install-run-rush.js version --bump --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
       - name: Simulate a publication to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
         if: ${{ env.MODE == 'simulate' }}
         run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
-      - name: Bump packages versions numbers for publication
-        if: ${{ env.MODE == 'publish' }}
-        run: node common/scripts/install-run-rush.js version --bump --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
+      # - name: Publish to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
+      #   if: ${{ env.MODE == 'publish' }}
+      #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
 
-      - name: Publish to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
-        if: ${{ env.MODE == 'publish' }}
-        run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
+      - name: Create Pull Request
+        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --reviewer bgatellier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,12 @@
+# Strategy
+#
+# 2 modes: simulate and publish
+# - simulate: pachages versions numbers bump and npmj.com publication are simulated in the workflow
+# - publication: a release branch is created that contains packages versions bumps and updated changelogs
+#
+# As we are using Rush version policies feature, we need to bump versions first:
+# https://rushjs.io/pages/maintainer/publishing/#publishing-process-when-version-policies-are-used
+
 name: 🚀 Publish packages
 
 on:
@@ -31,10 +40,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      MODE: ${{ inputs.MODE }}
+      # MODE: ${{ inputs.MODE }}
+      MODE: "simulate"
       SOURCE_BRANCH: master # Force the master branch to be deployed: avoid the publication of WIP code from other branches
       TARGET_BRANCH: release/${{ github.run_id }}
-      VERSION_POLICY: ${{ inputs.VERSION_POLICY }}
+      # VERSION_POLICY: ${{ inputs.VERSION_POLICY }}
+      VERSION_POLICY: "individualVersion"
     permissions:
       contents: write
       pull-requests: write
@@ -55,27 +66,34 @@ jobs:
           name: Heart
           email: heart@fabernovel.com
 
-      - name: Debug
-        run: env
+      # simulate mode
 
-      - name: Create origin/${{ env.TARGET_BRANCH }} branch and switch to it
-        run: git checkout -b $TARGET_BRANCH
+      # - name: Simulate packages versions numbers bump
+      #   if: ${{ env.MODE == 'simulate' }}
+      #   run: node common/scripts/install-run-rush.js version --bump --version-policy $VERSION_POLICY
 
-      # As we are using Rush version policies feature, we need to bump versions first:
-      # https://rushjs.io/pages/maintainer/publishing/#publishing-process-when-version-policies-are-used
+      # - name: Simulate a publication to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
+      #   if: ${{ env.MODE == 'simulate' }}
+      #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
+
+      # publish mode
+
+      - name: Create origin/${{ env.TARGET_BRANCH }} branch
+        # if: ${{ env.MODE == 'publish' }}
+        run: |
+          git checkout -b $TARGET_BRANCH
+          git push origin $TARGET_BRANCH
+          git checkout $SOURCE_BRANCH
+
       - name: Bump packages versions numbers
-        if: ${{ env.MODE == 'publish' }}
+        # if: ${{ env.MODE == 'publish' }}
         run: node common/scripts/install-run-rush.js version --bump --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
-
-      - name: Simulate a publication to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
-        if: ${{ env.MODE == 'simulate' }}
-        run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
       # - name: Publish to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
       #   if: ${{ env.MODE == 'publish' }}
       #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
 
       - name: Create Pull Request
-        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --reviewer bgatellier
+        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published" --reviewer bgatellier
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -68,32 +68,37 @@ jobs:
 
       # simulate mode
 
-      # - name: Simulate packages versions numbers bump
-      #   if: ${{ env.MODE == 'simulate' }}
-      #   run: node common/scripts/install-run-rush.js version --bump --version-policy $VERSION_POLICY
+      - name: Simulate packages versions numbers bump
+        if: ${{ env.MODE == 'simulate' }}
+        run: node common/scripts/install-run-rush.js version --bump --version-policy $VERSION_POLICY
 
-      # - name: Simulate a publication to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
-      #   if: ${{ env.MODE == 'simulate' }}
-      #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
+      - name: Simulate a publication to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
+        if: ${{ env.MODE == 'simulate' }}
+        run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
       # publish mode
 
       - name: Create origin/${{ env.TARGET_BRANCH }} branch
-        # if: ${{ env.MODE == 'publish' }}
+        if: ${{ env.MODE == 'publish' }}
         run: |
           git checkout -b $TARGET_BRANCH
           git push origin $TARGET_BRANCH
           git checkout $SOURCE_BRANCH
 
       - name: Bump packages versions numbers
-        # if: ${{ env.MODE == 'publish' }}
+        if: ${{ env.MODE == 'publish' }}
         run: node common/scripts/install-run-rush.js version --bump --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY
 
       # - name: Publish to npmjs.org with the ${{ env.VERSION_POLICY }} version policy
       #   if: ${{ env.MODE == 'publish' }}
       #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
 
-      - name: Create Pull Request
-        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published" --reviewer bgatellier
+      - name: Create, approve and merge a Pull Request
+        if:
+          ${{ env.MODE == 'publish' }}
+          # gh pr merge $TARGET_BRANCH --admin --squash --delete-branch
+        run: |
+          gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published"
+          gh pr review $TARGET_BRANCH --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,13 +93,16 @@ jobs:
       #   if: ${{ env.MODE == 'publish' }}
       #   run: node common/scripts/install-run-rush.js publish --include-all --target-branch $TARGET_BRANCH --version-policy $VERSION_POLICY --publish
 
-      - name: Create, approve and merge a Pull Request
-        if:
-          ${{ env.MODE == 'publish' }}
-          # Use --merge to keep the Git tags added by the previous step and move them to the $TARGET_BRANCH
-          # gh pr merge $TARGET_BRANCH --admin --merge --delete-branch
-        run: |
-          gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published"
-          gh pr review $TARGET_BRANCH --approve
+      - name: Create a Pull Request
+        if: ${{ env.MODE == 'publish' }}
+        run: gh pr create --base $SOURCE_BRANCH --head $TARGET_BRANCH --title "Release $GITHUB_RUN_ID" --body "Packages have been published" --no-maintainer-edit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Review and merge the Pull Request, then delete the branch
+        if: ${{ env.MODE == 'publish' }}
+        # Use --merge to keep the Git tags added by the previous step and move them to the $TARGET_BRANCH
+        # gh pr merge $TARGET_BRANCH --admin --merge --delete-branch
+        run: gh pr review $TARGET_BRANCH --approve
+        env:
+          GH_TOKEN: ${{ secrets.BGATELLIER_PAT }}


### PR DESCRIPTION
- Publish mode:
    - Create a branch named release/$GITHUB_RUN_ID
    - Execute Rush `version` and `publish` commands to push changes to this new branch
    - Create, review and merge a Pull Request from this new branch to `master` (without waiting branch workflow)
- Use .nvmrc file to set the Node.js version used in workflows

Resolves #25 