### PR TITLE
Fix: make the HTTP API responses always return every properties, with a null values if internally they do not exist or are undefined

### DIFF
--- a/common/changes/@fabernovel/heart-api/fix-api-return-null_2023-03-12-20-33.json
+++ b/common/changes/@fabernovel/heart-api/fix-api-return-null_2023-03-12-20-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-api",
+      "comment": "Add the service logo URL to the JSON response",
+      "type": "major"
+    }
+  ],
+  "packageName": "@fabernovel/heart-api"
+}

--- a/common/changes/@fabernovel/heart-api/fix-api-return-null_2023-03-12-20-34.json
+++ b/common/changes/@fabernovel/heart-api/fix-api-return-null_2023-03-12-20-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-api",
+      "comment": "Fix the JSON response to always show every properties (make the undefined properties null)",
+      "type": "major"
+    }
+  ],
+  "packageName": "@fabernovel/heart-api"
+}

--- a/modules/api/src/ExpressApp.ts
+++ b/modules/api/src/ExpressApp.ts
@@ -80,6 +80,7 @@ export class ExpressApp {
                   resultUrl: report.resultUrl ?? null,
                   service: {
                     name: report.service.name,
+                    logo: report.service.logo ?? null,
                   },
                   threshold: report.threshold ?? null,
                 })

--- a/modules/api/src/ExpressApp.ts
+++ b/modules/api/src/ExpressApp.ts
@@ -73,15 +73,15 @@ export class ExpressApp {
                 response.status(200).json({
                   analyzedUrl: report.analyzedUrl,
                   date: report.date,
+                  grade: report.grade,
+                  isThresholdReached: report.isThresholdReached() ?? null,
+                  normalizedGrade: report.normalizedGrade,
                   result: report.result,
+                  resultUrl: report.resultUrl ?? null,
                   service: {
                     name: report.service.name,
                   },
-                  grade: report.grade,
-                  normalizedGrade: report.normalizedGrade,
-                  resultUrl: report.resultUrl,
                   threshold: report.threshold ?? null,
-                  isThresholdReached: report.isThresholdReached() ?? null,
                 })
               })
               .catch(next)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1890804/224571609-3f487809-6599-4fae-9216-36b02abc24e6.png)

Resolves #78 
