### PR TITLE
fix: main branch name and small fixes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,8 +36,8 @@ on:
         required: true
 
 env:
-  # Force the master branch to be deployed, whatever the input is: avoid the publication of WIP code from other branches
-  SOURCE_BRANCH: master
+  # Force the main branch to be deployed, whatever the input is: avoid the publication of WIP code from other branches
+  SOURCE_BRANCH: main
   TARGET_BRANCH: release/${{ github.run_id }}
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Before making a new contribution, please check [the issues](https://github.com/f
 
 ### Create a _Pull Request_
 
-1. Create a branch for your enhancement from the `master` branch and push it to the remote
+1. Create a branch for your enhancement from the `main` branch and push it to the remote
 2. [Create a Pull Request from the GitHub interface](https://github.com/faberNovel/heart/compare) and select your branch
 
 ### [Setup your local environment](.docs/SETUP_LOCAL_ENVIRONMENT.md)

--- a/common/changes/@fabernovel/heart-api/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-api/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-api",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-api"
+}

--- a/common/changes/@fabernovel/heart-bigquery/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-bigquery/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-bigquery",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-bigquery"
+}

--- a/common/changes/@fabernovel/heart-cli/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-cli/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-cli"
+}

--- a/common/changes/@fabernovel/heart-common/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-common/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-common"
+}

--- a/common/changes/@fabernovel/heart-greenit/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-greenit/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-greenit",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-greenit"
+}

--- a/common/changes/@fabernovel/heart-lighthouse/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-lighthouse/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-lighthouse",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-lighthouse"
+}

--- a/common/changes/@fabernovel/heart-observatory/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-observatory/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-observatory",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-observatory"
+}

--- a/common/changes/@fabernovel/heart-slack/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-slack/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-slack",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-slack"
+}

--- a/common/changes/@fabernovel/heart-ssllabs-server/chore-main-branch-version-policy_2023-03-17-21-42.json
+++ b/common/changes/@fabernovel/heart-ssllabs-server/chore-main-branch-version-policy_2023-03-17-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-ssllabs-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-ssllabs-server"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -89,7 +89,7 @@
     //    *
     //    * Thus, warnings do not interfere with local development, but they will cause a CI job to fail, because
     //    * the Rush process itself returns a nonzero exit code if there are any warnings or errors. This is by design.
-    //    * In an active monorepo, we've found that if you allow any warnings in your master branch, it inadvertently
+    //    * In an active monorepo, we've found that if you allow any warnings in your main branch, it inadvertently
     //    * teaches developers to ignore warnings, which quickly leads to a situation where so many "expected" warnings
     //    * have accumulated that warnings no longer serve any useful purpose.
     //    *

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -81,8 +81,8 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "nextMajor",
-    "nextBump": "major",
-    "version": "3.0.0"
+    "nextBump": "prerelease",
+    "version": "4.0.0-alpha.2"
   },
   {
     "definitionName": "individualVersion",

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -4,7 +4,7 @@ _Heart API_ is a _runner_ module of _Heart_, which exposes an HTTP API that star
 
 Note that you must install an _analysis_ module too, to have a minimum viable installation of _Heart_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/bigquery/README.md
+++ b/modules/bigquery/README.md
@@ -4,7 +4,7 @@ _Heart BigQuery_ is a _listener_ module of _Heart_, which reacts at the end of a
 
 Note that you must install an _analysis_ module too, to have a minimum viable installation of _Heart_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/bigquery/src/index.ts
+++ b/modules/bigquery/src/index.ts
@@ -4,6 +4,6 @@ export default new BigQueryModule({
   name: "Heart BigQuery",
   service: {
     name: "Google BigQuery",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/BigQuery.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/BigQuery.png?v=20221126",
   },
 })

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -4,7 +4,7 @@ _Heart CLI_ is the control module of _Heart_. It allows every other module to wo
 
 Note that you must install an _analysis_ module too, to have a minimum viable installation of _Heart_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/common/README.md
+++ b/modules/common/README.md
@@ -4,4 +4,4 @@ _Heart Common_ centralize helpful code needed by every _Heart_ modules.
 
 THIS PACKAGE MUST NOT FIGURE IN YOUR DIRECT DEPENDENCIES.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -8,8 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@gitlab.com:fabernovel/heart.git",
-    "directory": "modules/core"
+    "url": "https://github.com/faberNovel/heart.git",
+    "directory": "modules/common"
   },
   "license": "MIT",
   "contributors": [

--- a/modules/dareboost/README.md
+++ b/modules/dareboost/README.md
@@ -4,7 +4,7 @@
 
 _Heart Dareboost_ is an _analysis_ module of _Heart_, which analyses URLs with _[Dareboost](https://www.dareboost.com/)_.
 
-Read more about [the purpose, design and general installation of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the purpose, design and general installation of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Package manager
 

--- a/modules/dareboost/src/index.ts
+++ b/modules/dareboost/src/index.ts
@@ -4,6 +4,6 @@ export default new DareboostModule({
   name: "Heart Dareboost",
   service: {
     name: "Dareboost",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/Dareboost.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/Dareboost.png?v=20221126",
   },
 })

--- a/modules/greenit/README.md
+++ b/modules/greenit/README.md
@@ -2,7 +2,7 @@
 
 _Heart GreenIT_ is an _analysis_ module of _Heart_, which analyses URLs with _[GreenIT](https://chrome.google.com/webstore/detail/greenit-analysis/mofbfhffeklkbebfclfaiifefjflcpad)_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/greenit/src/index.ts
+++ b/modules/greenit/src/index.ts
@@ -4,6 +4,6 @@ export default new GreenITModule({
   name: "Heart GreenIT",
   service: {
     name: "GreenIT Analysis",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/GreenIT.png?v=20221214",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/GreenIT.png?v=20221214",
   },
 })

--- a/modules/lighthouse/README.md
+++ b/modules/lighthouse/README.md
@@ -2,7 +2,7 @@
 
 _Heart Lighthouse_ is an _analysis_ module of _Heart_, which analyses URLs with _[Google Lighthouse](https://developers.google.com/web/tools/lighthouse/)_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/lighthouse/src/index.ts
+++ b/modules/lighthouse/src/index.ts
@@ -4,6 +4,6 @@ export default new LighthouseModule({
   name: "Heart Lighthouse",
   service: {
     name: "Google Lighthouse",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/Lighthouse.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/Lighthouse.png?v=20221126",
   },
 })

--- a/modules/moduletpl/src/index.ts
+++ b/modules/moduletpl/src/index.ts
@@ -4,6 +4,6 @@ export default new ModuleTplModule({
   name: "Heart ModuleTpl",
   service: {
     name: "ModuleTpl",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/ModuleTpl.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/ModuleTpl.png?v=20221126",
   },
 })

--- a/modules/observatory/README.md
+++ b/modules/observatory/README.md
@@ -2,7 +2,7 @@
 
 _Heart Observatory_ is an _analysis_ module of _Heart_, which analyses URLs with _[Mozilla Observatory](https://observatory.mozilla.org/)_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/observatory/src/index.ts
+++ b/modules/observatory/src/index.ts
@@ -4,6 +4,6 @@ export default new ObservatoryModule({
   name: "Heart Observatory",
   service: {
     name: "Mozilla Observatory",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/Observatory.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/Observatory.png?v=20221126",
   },
 })

--- a/modules/slack/README.md
+++ b/modules/slack/README.md
@@ -4,7 +4,7 @@ _Heart Slack_ is a _listener_ module of _Heart_, which reacts to the end of an a
 
 Note that you must install an _analysis_ module too, to have a minimum viable installation of _Heart_.
 
-Read more about [the description and design of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the description and design of _Heart_](https://github.com/faberNovel/heart#readme).
 
 
 # Usage

--- a/modules/slack/src/index.ts
+++ b/modules/slack/src/index.ts
@@ -4,6 +4,6 @@ export default new SlackModule({
   name: "Heart Slack",
   service: {
     name: "Slack",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/Slack.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/Slack.png?v=20221126",
   },
 })

--- a/modules/ssllabs-server/README.md
+++ b/modules/ssllabs-server/README.md
@@ -2,7 +2,7 @@
 
 _Heart SSL Labs Server_ is an _analysis_ module of _Heart_, which analyses URLs with _[Qualys SSL Labs server](https://www.ssllabs.com/ssltest/index.html)_.
 
-Read more about [the purpose, design and general installation of _Heart_](https://gitlab.com/fabernovel/heart/-/blob/master/README.md).
+Read more about [the purpose, design and general installation of _Heart_](https://github.com/faberNovel/heart#readme).
 
 # Usage
 

--- a/modules/ssllabs-server/src/index.ts
+++ b/modules/ssllabs-server/src/index.ts
@@ -4,6 +4,6 @@ export default new SsllabsServerModule({
   name: "Heart SSL Labs Server",
   service: {
     name: "Qualys SSL Labs Server",
-    logo: "https://raw.githubusercontent.com/faberNovel/heart/master/assets/images/logos/SSLLabs.png?v=20221126",
+    logo: "https://raw.githubusercontent.com/faberNovel/heart/main/assets/images/logos/SSLLabs.png?v=20221126",
   },
 })

--- a/rush.json
+++ b/rush.json
@@ -233,7 +233,7 @@
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "main"
      */
-    "defaultBranch": "master"
+    "defaultBranch": "main"
   },
 
   /**

--- a/rush.json
+++ b/rush.json
@@ -80,7 +80,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=14.17.0",
+  "nodeSupportedVersionRange": ">=18 <20",
 
   /**
    * If you would like the version specifiers for your dependencies to be consistent, then

--- a/rush.json
+++ b/rush.json
@@ -216,16 +216,16 @@
      * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
      *
      * The "rush change" command needs to determine which files are affected by your PR diff.
-     * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
+     * If you merged or cherry-picked commits from the main branch into your PR branch, those commits
      * should be excluded from this diff (since they belong to some other PR).  In order to do that,
      * Rush needs to know where to find the base branch for your PR.  This information cannot be
      * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
      * Rush would use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
-     * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
+     * But to keep things simple, "rush change" simply assumes that your PR is against the "main" branch
      * of the Git remote indicated by the respository.url setting in rush.json.  If you are working in
      * a GitHub "fork" of the real repo, this setting will be different from the repository URL of your
      * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
-     * to retrieve the latest activity for the remote master branch.
+     * to retrieve the latest activity for the remote main branch.
      */
     "url": "git@github.com:faberNovel/heart.git",
 


### PR DESCRIPTION
- Fix `master` branch references
- Fix version policy
- Fix Node.js version range checked by Rush
- Fix docs URLs that did still redirect to the old GitLab repository
- Fix a URL to the old GitLab in the package.json of the Common module

Resolves #99 