### PR TITLE
Feat: make the listener modules aware of the input config

### DIFF
--- a/common/changes/@fabernovel/heart-api/feat-send-config-to-listeners_2023-05-11-20-12.json
+++ b/common/changes/@fabernovel/heart-api/feat-send-config-to-listeners_2023-05-11-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-api",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-api"
+}

--- a/common/changes/@fabernovel/heart-bigquery/feat-send-config-to-listeners_2023-05-11-20-12.json
+++ b/common/changes/@fabernovel/heart-bigquery/feat-send-config-to-listeners_2023-05-11-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-bigquery",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-bigquery"
+}

--- a/common/changes/@fabernovel/heart-cli/feat-send-config-to-listeners_2023-05-11-20-12.json
+++ b/common/changes/@fabernovel/heart-cli/feat-send-config-to-listeners_2023-05-11-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-cli"
+}

--- a/common/changes/@fabernovel/heart-common/feat-send-config-to-listeners_2023-05-11-20-12.json
+++ b/common/changes/@fabernovel/heart-common/feat-send-config-to-listeners_2023-05-11-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-common"
+}

--- a/common/changes/@fabernovel/heart-greenit/feat-send-config-to-listeners_2023-05-11-21-04.json
+++ b/common/changes/@fabernovel/heart-greenit/feat-send-config-to-listeners_2023-05-11-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-greenit",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-greenit"
+}

--- a/common/changes/@fabernovel/heart-lighthouse/feat-send-config-to-listeners_2023-05-11-21-04.json
+++ b/common/changes/@fabernovel/heart-lighthouse/feat-send-config-to-listeners_2023-05-11-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-lighthouse",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-lighthouse"
+}

--- a/common/changes/@fabernovel/heart-observatory/feat-send-config-to-listeners_2023-05-11-21-04.json
+++ b/common/changes/@fabernovel/heart-observatory/feat-send-config-to-listeners_2023-05-11-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-observatory",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-observatory"
+}

--- a/common/changes/@fabernovel/heart-slack/feat-send-config-to-listeners_2023-05-11-20-12.json
+++ b/common/changes/@fabernovel/heart-slack/feat-send-config-to-listeners_2023-05-11-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-slack",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-slack"
+}

--- a/common/changes/@fabernovel/heart-ssllabs-server/feat-send-config-to-listeners_2023-05-11-21-04.json
+++ b/common/changes/@fabernovel/heart-ssllabs-server/feat-send-config-to-listeners_2023-05-11-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-ssllabs-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-ssllabs-server"
+}

--- a/modules/api/src/router/RouteHandler.ts
+++ b/modules/api/src/router/RouteHandler.ts
@@ -24,6 +24,10 @@ export function createRouteHandler(
       analyzedUrl: report.analyzedUrl,
       date: report.date,
       grade: report.grade,
+      inputs: {
+        config: report.inputs.config,
+        threshold: report.inputs.threshold ?? null,
+      },
       isThresholdReached: report.isThresholdReached() ?? null,
       normalizedGrade: report.normalizedGrade,
       result: report.result,
@@ -32,7 +36,6 @@ export function createRouteHandler(
         name: report.service.name,
         logo: report.service.logo ?? null,
       },
-      threshold: report.threshold ?? null,
     })
   }
 }

--- a/modules/api/tests/data/AnalysisModules.ts
+++ b/modules/api/tests/data/AnalysisModules.ts
@@ -19,6 +19,9 @@ export const analysisModules: ModuleAnalysisInterface<Config, GenericReport<Resu
         new GreenITReport({
           analyzedUrl: "",
           date: new Date(),
+          inputs: {
+            config: {},
+          },
           result: {} as unknown as GreenITReport["result"],
           service: {
             name: "GreenIT Analysis",
@@ -37,6 +40,9 @@ export const analysisModules: ModuleAnalysisInterface<Config, GenericReport<Resu
         new ObservatoryReport({
           analyzedUrl: "",
           date: new Date(),
+          inputs: {
+            config: {},
+          },
           result: {
             scan: {
               grade: "",

--- a/modules/bigquery/src/api/BigQuery/model/RowReport.ts
+++ b/modules/bigquery/src/api/BigQuery/model/RowReport.ts
@@ -20,6 +20,6 @@ export class RowReport<R extends Result> {
     this.ranking = new RecordRanking(report.grade, Math.round(report.normalizedGrade))
     this.service = new RecordService(report.service.name)
     this.url = new RecordUrl(report.analyzedUrl, report.resultUrl)
-    this.threshold = new RecordThreshold(report.threshold, report.isThresholdReached())
+    this.threshold = new RecordThreshold(report.inputs.threshold, report.isThresholdReached())
   }
 }

--- a/modules/cli/src/command/cli/CliCommand.ts
+++ b/modules/cli/src/command/cli/CliCommand.ts
@@ -37,13 +37,13 @@ export async function start(): Promise<Command> {
   // analysis modules: create a command for each of them
   analysisModulesMap.forEach((analysisModule, modulePath) => {
     const callback = async <C extends Config>(
-      conf: C,
+      config: C,
       threshold: number | undefined,
       listenerModulesFiltered: ModuleListenerInterface[]
     ) => {
       loadEnvironmentVariables(modulePath)
 
-      const report = await startAnalysis(analysisModule, conf, threshold)
+      const report = await startAnalysis(analysisModule, config, threshold)
 
       // notify filtered listener modules
       await notifyListenerModules(listenerModulesFiltered, report)

--- a/modules/cli/tests/command/AnalysisCommand.test.ts
+++ b/modules/cli/tests/command/AnalysisCommand.test.ts
@@ -11,6 +11,9 @@ test("Create an analysis command", () => {
   const report = new GreenITReport({
     analyzedUrl: "https://heart.fabernovel.com",
     date: new Date(),
+    inputs: {
+      config: {},
+    },
     result: {
       grade: "B",
       ecoIndex: 50,

--- a/modules/cli/tests/module/ModuleOrchestrator.test.ts
+++ b/modules/cli/tests/module/ModuleOrchestrator.test.ts
@@ -6,6 +6,9 @@ test("Displays the results of an analysis", async () => {
   const report = new GreenITReport({
     analyzedUrl: "https://heart.fabernovel.com",
     date: new Date(),
+    inputs: {
+      config: {},
+    },
     result: {
       grade: "B",
       ecoIndex: 50,

--- a/modules/common/src/report/Report.ts
+++ b/modules/common/src/report/Report.ts
@@ -1,3 +1,4 @@
+import type { ValidatedAnalysisInput } from "../index.js"
 import type { Service } from "../service/Service.js"
 
 /**
@@ -26,10 +27,7 @@ interface ReportBase {
    */
   service: Service
 
-  /**
-   * Threshold
-   */
-  threshold?: number
+  inputs: Pick<ValidatedAnalysisInput, "config" | "threshold">
 }
 
 interface ValueHolder<A> {

--- a/modules/common/src/report/greenit/GreenITReport.ts
+++ b/modules/common/src/report/greenit/GreenITReport.ts
@@ -1,3 +1,4 @@
+import type { ValidatedAnalysisInput } from "../../index.js"
 import type { Service } from "../../service/Service.js"
 import type { GenericReport, ReportArguments } from "../Report.js"
 import type { GreenITResult } from "./GreenITResult.js"
@@ -8,15 +9,15 @@ export class GreenITReport implements GenericReport<GreenITResult> {
   #result: GreenITResult
   #resultUrl: string | undefined
   #service: Service
-  #threshold: number | undefined
+  #inputs: Pick<ValidatedAnalysisInput, "config" | "threshold">
 
-  constructor({ analyzedUrl, date, result, resultUrl, service, threshold }: ReportArguments<GreenITResult>) {
+  constructor({ analyzedUrl, date, result, resultUrl, service, inputs }: ReportArguments<GreenITResult>) {
     this.#analyzedUrl = analyzedUrl
     this.#date = date
     this.#result = result
     this.#resultUrl = resultUrl
     this.#service = service
-    this.#threshold = threshold
+    this.#inputs = inputs
   }
 
   get analyzedUrl(): string {
@@ -47,8 +48,8 @@ export class GreenITReport implements GenericReport<GreenITResult> {
     return this.#service
   }
 
-  get threshold(): number | undefined {
-    return this.#threshold
+  get inputs(): Pick<ValidatedAnalysisInput, "config" | "threshold"> {
+    return this.#inputs
   }
 
   displayGrade(): string {
@@ -58,6 +59,6 @@ export class GreenITReport implements GenericReport<GreenITResult> {
   }
 
   isThresholdReached(): boolean | undefined {
-    return this.threshold !== undefined ? this.normalizedGrade >= this.threshold : undefined
+    return this.inputs.threshold !== undefined ? this.normalizedGrade >= this.inputs.threshold : undefined
   }
 }

--- a/modules/common/src/report/lighthouse/LighthouseReport.ts
+++ b/modules/common/src/report/lighthouse/LighthouseReport.ts
@@ -2,6 +2,7 @@ import type { Result } from "lighthouse"
 import type { Service } from "../../service/Service.js"
 import type { GenericReport, ReportArguments } from "../Report.js"
 import type { LighthouseResult } from "./LighthouseResult.js"
+import type { ValidatedAnalysisInput } from "../../index.js"
 
 const compute = (categories: Record<string, Result.Category>, fractionDigits?: number): number => {
   const avgScore = computeCategories(categories)
@@ -51,22 +52,15 @@ export class LighthouseReport implements GenericReport<LighthouseResult> {
   #result: LighthouseResult
   #resultUrl: string | undefined
   #service: Service
-  #threshold: number | undefined
+  #inputs: Pick<ValidatedAnalysisInput, "config" | "threshold">
 
-  constructor({
-    analyzedUrl,
-    date,
-    result,
-    resultUrl,
-    service,
-    threshold,
-  }: ReportArguments<LighthouseResult>) {
+  constructor({ analyzedUrl, date, result, resultUrl, service, inputs }: ReportArguments<LighthouseResult>) {
     this.#analyzedUrl = analyzedUrl
     this.#date = date
     this.#result = result
     this.#resultUrl = resultUrl
     this.#service = service
-    this.#threshold = threshold
+    this.#inputs = inputs
 
     this.#normalizedGrade = compute(this.#result.categories)
     this.#grade = this.#normalizedGrade.toString()
@@ -100,8 +94,8 @@ export class LighthouseReport implements GenericReport<LighthouseResult> {
     return this.#service
   }
 
-  get threshold(): number | undefined {
-    return this.#threshold
+  get inputs(): Pick<ValidatedAnalysisInput, "config" | "threshold"> {
+    return this.#inputs
   }
 
   displayGrade(): string {
@@ -111,6 +105,6 @@ export class LighthouseReport implements GenericReport<LighthouseResult> {
   }
 
   isThresholdReached(): boolean | undefined {
-    return this.threshold !== undefined ? this.normalizedGrade >= this.threshold : undefined
+    return this.inputs.threshold !== undefined ? this.normalizedGrade >= this.inputs.threshold : undefined
   }
 }

--- a/modules/common/src/report/observatory/ObservatoryReport.ts
+++ b/modules/common/src/report/observatory/ObservatoryReport.ts
@@ -1,3 +1,4 @@
+import type { ValidatedAnalysisInput } from "../../index.js"
 import type { Service } from "../../service/Service.js"
 import type { GenericReport, ReportArguments } from "../Report.js"
 import type { ObservatoryResult } from "./ObservatoryResult.js"
@@ -8,22 +9,15 @@ export class ObservatoryReport implements GenericReport<ObservatoryResult> {
   #result: ObservatoryResult
   #resultUrl: string | undefined
   #service: Service
-  #threshold: number | undefined
+  #inputs: Pick<ValidatedAnalysisInput, "config" | "threshold">
 
-  constructor({
-    analyzedUrl,
-    date,
-    result,
-    resultUrl,
-    service,
-    threshold,
-  }: ReportArguments<ObservatoryResult>) {
+  constructor({ analyzedUrl, date, result, resultUrl, service, inputs }: ReportArguments<ObservatoryResult>) {
     this.#analyzedUrl = analyzedUrl
     this.#date = date
     this.#result = result
     this.#resultUrl = resultUrl
     this.#service = service
-    this.#threshold = threshold
+    this.#inputs = inputs
   }
 
   get analyzedUrl(): string {
@@ -54,8 +48,8 @@ export class ObservatoryReport implements GenericReport<ObservatoryResult> {
     return this.#service
   }
 
-  get threshold(): number | undefined {
-    return this.#threshold
+  get inputs(): Pick<ValidatedAnalysisInput, "config" | "threshold"> {
+    return this.#inputs
   }
 
   displayGrade(): string {
@@ -65,6 +59,6 @@ export class ObservatoryReport implements GenericReport<ObservatoryResult> {
   }
 
   isThresholdReached(): boolean | undefined {
-    return this.threshold !== undefined ? this.normalizedGrade >= this.threshold : undefined
+    return this.inputs.threshold !== undefined ? this.normalizedGrade >= this.inputs.threshold : undefined
   }
 }

--- a/modules/common/src/report/ssllabs-server/SsllabsServerReport.ts
+++ b/modules/common/src/report/ssllabs-server/SsllabsServerReport.ts
@@ -1,3 +1,4 @@
+import type { ValidatedAnalysisInput } from "../../index.js"
 import type { Service } from "../../service/Service.js"
 import type { GenericReport, ReportArguments } from "../Report.js"
 import type { SsllabsServerGrade } from "./enum/SsllabsServerGrade.js"
@@ -52,7 +53,7 @@ export class SsllabsServerReport implements GenericReport<SsllabsServerResult> {
   #result: SsllabsServerResult
   #resultUrl: string | undefined
   #service: Service
-  #threshold: number | undefined
+  #inputs: Pick<ValidatedAnalysisInput, "config" | "threshold">
 
   constructor({
     analyzedUrl,
@@ -60,14 +61,14 @@ export class SsllabsServerReport implements GenericReport<SsllabsServerResult> {
     result,
     resultUrl,
     service,
-    threshold,
+    inputs,
   }: ReportArguments<SsllabsServerResult>) {
     this.#analyzedUrl = analyzedUrl
     this.#date = date
     this.#result = result
     this.#resultUrl = resultUrl
     this.#service = service
-    this.#threshold = threshold
+    this.#inputs = inputs
 
     this.#normalizedGrade = computeEndpoints(this.#result.endpoints)
     this.#grade = this.#normalizedGrade.toString()
@@ -101,8 +102,8 @@ export class SsllabsServerReport implements GenericReport<SsllabsServerResult> {
     return this.#service
   }
 
-  get threshold(): number | undefined {
-    return this.#threshold
+  get inputs(): Pick<ValidatedAnalysisInput, "config" | "threshold"> {
+    return this.#inputs
   }
 
   displayGrade(): string {
@@ -112,6 +113,6 @@ export class SsllabsServerReport implements GenericReport<SsllabsServerResult> {
   }
 
   isThresholdReached(): boolean | undefined {
-    return this.threshold !== undefined ? this.normalizedGrade >= this.threshold : undefined
+    return this.inputs.threshold !== undefined ? this.normalizedGrade >= this.inputs.threshold : undefined
   }
 }

--- a/modules/greenit/src/GreenITModule.ts
+++ b/modules/greenit/src/GreenITModule.ts
@@ -1,19 +1,19 @@
-import type { GreenITConfig } from "@fabernovel/heart-common"
+import type { Config, GreenITConfig } from "@fabernovel/heart-common"
 import { Module, ModuleAnalysisInterface, GreenITReport } from "@fabernovel/heart-common"
 import { requestResult } from "./api/Client.js"
 
 export class GreenITModule extends Module implements ModuleAnalysisInterface<GreenITConfig, GreenITReport> {
   private threshold?: number
 
-  public async startAnalysis(conf: GreenITConfig, threshold?: number): Promise<GreenITReport> {
+  public async startAnalysis(config: GreenITConfig, threshold?: number): Promise<GreenITReport> {
     this.threshold = threshold
 
-    const result = await requestResult(conf)
+    const result = await requestResult(config)
 
-    return this.handleResult(result)
+    return this.handleResult(config, result)
   }
 
-  private handleResult(result: GreenITReport["result"]): GreenITReport {
+  private handleResult(config: Config, result: GreenITReport["result"]): GreenITReport {
     const [date, time] = result.date.split(" ")
     const [day, month, year] = date.split("/")
 
@@ -22,7 +22,10 @@ export class GreenITModule extends Module implements ModuleAnalysisInterface<Gre
       date: new Date(`${year}-${month}-${day}T${time}`),
       result: result,
       service: this.service,
-      threshold: this.threshold,
+      inputs: {
+        config: config,
+        threshold: this.threshold,
+      },
     })
   }
 }

--- a/modules/greenit/src/api/Client.ts
+++ b/modules/greenit/src/api/Client.ts
@@ -10,7 +10,7 @@ const DEFAULT_OPTIONS: Options = {
   timeout: 3000,
 }
 
-export async function requestResult(conf: GreenITConfig): Promise<GreenITReport["result"]> {
+export async function requestResult(config: GreenITConfig): Promise<GreenITReport["result"]> {
   const browser = await puppeteer.launch({
     headless: true,
     args: [
@@ -23,10 +23,10 @@ export async function requestResult(conf: GreenITConfig): Promise<GreenITReport[
 
   const options: Options = {
     ci: true,
-    device: conf.device ?? DEFAULT_OPTIONS.device,
+    device: config.device ?? DEFAULT_OPTIONS.device,
     max_tab: DEFAULT_OPTIONS.max_tab,
-    retry: conf.retry ?? DEFAULT_OPTIONS.retry,
-    timeout: conf.timeout ?? DEFAULT_OPTIONS.timeout,
+    retry: config.retry ?? DEFAULT_OPTIONS.retry,
+    timeout: config.timeout ?? DEFAULT_OPTIONS.timeout,
   }
 
   const reports = new Array<Report>()
@@ -42,7 +42,7 @@ export async function requestResult(conf: GreenITConfig): Promise<GreenITReport[
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     console.error = () => {}
 
-    const r = await createJsonReports(browser, [{ url: conf.url }], options)
+    const r = await createJsonReports(browser, [{ url: config.url }], options)
 
     reports.push(...r)
   } catch (error) {

--- a/modules/greenit/tests/GreenITModule.test.ts
+++ b/modules/greenit/tests/GreenITModule.test.ts
@@ -39,7 +39,7 @@ describe("Run GreenIT analysis", () => {
     expect(analysisReport).toHaveProperty("grade", SuccessResult.grade)
     expect(analysisReport).toHaveProperty("normalizedGrade", SuccessResult.ecoIndex)
     expect(analysisReport).toHaveProperty("service", moduleConfig.service)
-    expect(analysisReport).toHaveProperty("threshold", undefined)
+    expect(analysisReport).toHaveProperty("inputs", { config: Conf })
   })
 
   it("should be able to handle a failed analysis", async () => {
@@ -96,7 +96,7 @@ describe("Run GreenIT analysis", () => {
     expect(analysisReport).toHaveProperty("grade", SuccessResult.grade)
     expect(analysisReport).toHaveProperty("normalizedGrade", SuccessResult.ecoIndex)
     expect(analysisReport).toHaveProperty("service", moduleConfig.service)
-    expect(analysisReport).toHaveProperty("threshold", THRESHOLD)
+    expect(analysisReport).toHaveProperty("inputs", { config: Conf, threshold: THRESHOLD })
   })
 
   it("Should return false when results do not match thresholds objectives", async () => {
@@ -126,7 +126,7 @@ describe("Run GreenIT analysis", () => {
     expect(analysisReport).toHaveProperty("grade", SuccessResult.grade)
     expect(analysisReport).toHaveProperty("normalizedGrade", SuccessResult.ecoIndex)
     expect(analysisReport).toHaveProperty("service", moduleConfig.service)
-    expect(analysisReport).toHaveProperty("threshold", THRESHOLD)
+    expect(analysisReport).toHaveProperty("inputs", { config: Conf, threshold: THRESHOLD })
     expect(analysisReport.isThresholdReached()).toStrictEqual(false)
   })
 })

--- a/modules/lighthouse/src/LighthouseModule.ts
+++ b/modules/lighthouse/src/LighthouseModule.ts
@@ -1,4 +1,10 @@
-import { LighthouseConfig, LighthouseReport, Module, ModuleAnalysisInterface } from "@fabernovel/heart-common"
+import {
+  Config,
+  LighthouseConfig,
+  LighthouseReport,
+  Module,
+  ModuleAnalysisInterface,
+} from "@fabernovel/heart-common"
 import { requestResult } from "./api/Client.js"
 
 export class LighthouseModule
@@ -7,21 +13,24 @@ export class LighthouseModule
 {
   private threshold?: number
 
-  public async startAnalysis(conf: LighthouseConfig, threshold?: number): Promise<LighthouseReport> {
+  public async startAnalysis(config: LighthouseConfig, threshold?: number): Promise<LighthouseReport> {
     this.threshold = threshold
 
-    const result = await requestResult(conf)
+    const result = await requestResult(config)
 
-    return this.handleResult(result)
+    return this.handleResult(config, result)
   }
 
-  private handleResult(result: LighthouseReport["result"]): LighthouseReport {
+  private handleResult(config: Config, result: LighthouseReport["result"]): LighthouseReport {
     return new LighthouseReport({
       analyzedUrl: result.requestedUrl as string,
       date: new Date(result.fetchTime),
       result: result,
       service: this.service,
-      threshold: this.threshold,
+      inputs: {
+        config: config,
+        threshold: this.threshold,
+      },
     })
   }
 }

--- a/modules/observatory/src/ObservatoryModule.ts
+++ b/modules/observatory/src/ObservatoryModule.ts
@@ -15,15 +15,15 @@ export class ObservatoryModule
 {
   #client = new Client()
 
-  public async startAnalysis(conf: ObservatoryConfig, threshold?: number): Promise<ObservatoryReport> {
-    const scan = await this.#client.triggerAnalysis(conf)
+  public async startAnalysis(config: ObservatoryConfig, threshold?: number): Promise<ObservatoryReport> {
+    const scan = await this.#client.triggerAnalysis(config)
 
     const finishedScan = await this.requestFinishedScan(scan)
 
     const tests = await this.#client.requestTests(finishedScan)
 
     return new ObservatoryReport({
-      analyzedUrl: conf.host,
+      analyzedUrl: config.host,
       date: new Date(finishedScan.end_time),
       result: {
         scan: finishedScan,
@@ -31,7 +31,10 @@ export class ObservatoryModule
       },
       resultUrl: this.#client.getAnalyzeUrl(),
       service: this.service,
-      threshold: threshold,
+      inputs: {
+        config: config,
+        threshold: threshold,
+      },
     })
   }
 

--- a/modules/observatory/tests/ObservatoryModule.test.ts
+++ b/modules/observatory/tests/ObservatoryModule.test.ts
@@ -34,6 +34,9 @@ describe("Starts an analysis", () => {
     const expectedReport = new ObservatoryReport({
       analyzedUrl: "heart.fabernovel.com",
       date: report.date,
+      inputs: {
+        config: CONF,
+      },
       result: RESULT,
       resultUrl: ANALYZE_URL + "heart.fabernovel.com",
       service: {
@@ -58,6 +61,9 @@ describe("Starts an analysis", () => {
     const expectedReport = new ObservatoryReport({
       analyzedUrl: "heart.fabernovel.com",
       date: report.date,
+      inputs: {
+        config: CONF,
+      },
       result: RESULT,
       resultUrl: ANALYZE_URL + "heart.fabernovel.com",
       service: {
@@ -66,7 +72,7 @@ describe("Starts an analysis", () => {
     })
 
     expect(report).toStrictEqual(expectedReport)
-    expect(report).toHaveProperty("threshold", undefined)
+    expect(report).toHaveProperty("inputs", { config: CONF })
   })
 
   it("Should return false status when results do not match threshold objective", async () => {
@@ -76,9 +82,12 @@ describe("Starts an analysis", () => {
     const expectedReport = new ObservatoryReport({
       analyzedUrl: "heart.fabernovel.com",
       date: report.date,
+      inputs: {
+        config: CONF,
+        threshold: THRESHOLD,
+      },
       result: RESULT,
       resultUrl: ANALYZE_URL + "heart.fabernovel.com",
-      threshold: THRESHOLD,
       service: {
         name: "Observatory Test",
       },

--- a/modules/slack/src/formatter/BlocksFormatter.ts
+++ b/modules/slack/src/formatter/BlocksFormatter.ts
@@ -61,8 +61,8 @@ const createBlocks = (
       elements.push({
         type: "mrkdwn",
         text: report.isThresholdReached()
-          ? `:white_check_mark: Threshold (${report.threshold as number}) reached`
-          : `:warning: Threshold (${report.threshold as number}) not reached`,
+          ? `:white_check_mark: Threshold (${report.inputs.threshold as number}) reached`
+          : `:warning: Threshold (${report.inputs.threshold as number}) not reached`,
       })
     }
 


### PR DESCRIPTION
-Refactor the `Report`: add a new `inputs` property that contains the config and the threshold (the threshold property of the report has been removed)

Resolves #102 