### PR TITLE
chore: move the removeComments option to the tsconfig.json root file

### DIFF
--- a/common/changes/@fabernovel/heart-api/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-api/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-api",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-api"
+}

--- a/common/changes/@fabernovel/heart-cli/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-cli/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-cli"
+}

--- a/common/changes/@fabernovel/heart-common/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-common/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-common"
+}

--- a/common/changes/@fabernovel/heart-greenit/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-greenit/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-greenit",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-greenit"
+}

--- a/common/changes/@fabernovel/heart-lighthouse/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-lighthouse/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-lighthouse",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-lighthouse"
+}

--- a/common/changes/@fabernovel/heart-mysql/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-mysql/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-mysql",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-mysql"
+}

--- a/common/changes/@fabernovel/heart-observatory/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-observatory/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-observatory",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-observatory"
+}

--- a/common/changes/@fabernovel/heart-slack/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-slack/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-slack",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-slack"
+}

--- a/common/changes/@fabernovel/heart-ssllabs-server/chore-simplify-tsconfig_2023-08-21-21-54.json
+++ b/common/changes/@fabernovel/heart-ssllabs-server/chore-simplify-tsconfig_2023-08-21-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@fabernovel/heart-ssllabs-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@fabernovel/heart-ssllabs-server"
+}

--- a/modules/api/tsconfig.build.json
+++ b/modules/api/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/cli/tsconfig.build.json
+++ b/modules/cli/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/common/tsconfig.build.json
+++ b/modules/common/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/greenit/tsconfig.build.json
+++ b/modules/greenit/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/lighthouse/tsconfig.build.json
+++ b/modules/lighthouse/tsconfig.build.json
@@ -5,8 +5,7 @@
 
   "compilerOptions": {
     "esModuleInterop": false,
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/mysql/tsconfig.build.json
+++ b/modules/mysql/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/observatory/tsconfig.build.json
+++ b/modules/observatory/tsconfig.build.json
@@ -5,8 +5,7 @@
 
   "compilerOptions": {
     "esModuleInterop": false,
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/slack/tsconfig.build.json
+++ b/modules/slack/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/ssllabs-server/tsconfig.build.json
+++ b/modules/ssllabs-server/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/tpl/tsconfig.build.json
+++ b/modules/tpl/tsconfig.build.json
@@ -4,8 +4,7 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "lib",
-    "removeComments": true
+    "outDir": "lib"
   },
 
   "include": ["src/**/*.ts"]

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -17,15 +17,11 @@
     "verbatimModuleSyntax": true,
 
     "declaration": true,
+    "removeComments": true,
 
     "module": "ESNext",
     "moduleResolution": "nodenext",
-    "target": "ESNext",
-
-    /**
-     * Disabled because of puppeteer-core bug in TypeScript file definition with ESM
-     */
-    "skipLibCheck": true
+    "target": "ESNext"
   },
 
   "exclude": ["node_modules", "lib"]

--- a/rush.json
+++ b/rush.json
@@ -380,57 +380,68 @@
     {
       "packageName": "@fabernovel/heart-test",
       "projectFolder": "test",
-      "shouldPublish": false
+      "shouldPublish": false,
+      "tags": ["test"]
     },
     {
       "packageName": "@fabernovel/heart-api",
       "projectFolder": "modules/api",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["server", "api"]
     },
     {
       "packageName": "@fabernovel/heart-cli",
       "projectFolder": "modules/cli",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["cli"]
     },
     {
       "packageName": "@fabernovel/heart-common",
       "projectFolder": "modules/common",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["common"]
     },
     {
       "packageName": "@fabernovel/heart-greenit",
       "projectFolder": "modules/greenit",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["analysis", "greenit"]
     },
     {
       "packageName": "@fabernovel/heart-lighthouse",
       "projectFolder": "modules/lighthouse",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["analysis", "lighthouse"]
     },
     {
       "packageName": "@fabernovel/heart-mysql",
       "projectFolder": "modules/mysql",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["listener", "mysql"]
     },
     {
       "packageName": "@fabernovel/heart-observatory",
       "projectFolder": "modules/observatory",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["analysis", "observatory"]
     },
     {
       "packageName": "@fabernovel/heart-slack",
       "projectFolder": "modules/slack",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["listener", "slack"]
     },
     {
       "packageName": "@fabernovel/heart-ssllabs-server",
       "projectFolder": "modules/ssllabs-server",
-      "versionPolicyName": "nextMajor"
+      "versionPolicyName": "nextMajor",
+      "tags": ["analysis", "ssllabs-server"]
     },
     {
       "packageName": "@fabernovel/heart-tpl",
       "projectFolder": "modules/tpl",
-      "shouldPublish": false
+      "shouldPublish": false,
+      "tags": ["tpl"]
     }
   ]
 }


### PR DESCRIPTION
- Centralize the `removeComments` tsc option
- Add tags to projects to make them quickly targetable with the `--only` (`-o`) option  (example: `rush test -o tag:common`). Add tags to target `analysis`, `listener` and `server` modules