### PR TITLE
ci: make the PR-related jobs fail afer 5 minutes

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -11,6 +11,7 @@ jobs:
   generate:
     name: Generate coverage reports
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,7 @@ jobs:
   syntax_changelog:
     name: Syntax & changelog
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     defaults:
       run:
         shell: bash
@@ -37,6 +38,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
[Recent manual dependency upgrade](https://github.com/faberNovel/heart/pull/188) make the tests timeout locally, and [didn't make the CI fail over 15 minutes (!)](https://github.com/faberNovel/heart/actions/runs/6447324672).

This PR ensure that the CI fails sooner to:
- indicates that something went wrong in the code
- reduce CI resource consumption (CPU, memory...)